### PR TITLE
Implement helper methods for container URL and iCloud availability.

### DIFF
--- a/ios/Classes/IcloudStorageSyncPlugin.swift
+++ b/ios/Classes/IcloudStorageSyncPlugin.swift
@@ -27,6 +27,13 @@ public class IcloudStorageSyncPlugin: NSObject, FlutterPlugin {
             } else {
                 result(FlutterError(code: "INVALID_ARGUMENT", message: "containerId not provided", details: nil))
             }
+        case "getICloudContainerUrl":
+            if let args = call.arguments as? [String: Any],
+               let containerId = args["containerId"] as? String {
+                getICloudContainerUrl(containerId: containerId, result: result)
+            } else {
+                result(FlutterError(code: "INVALID_ARGUMENT", message: "containerId not provided", details: nil))
+            }
         case "upload":
             upload(call, result) 
         case "delete":
@@ -155,6 +162,15 @@ public class IcloudStorageSyncPlugin: NSObject, FlutterPlugin {
         } catch {
             result(FlutterError(code: "ICLOUD_ERROR", message: "Error accessing iCloud Drive", details: error.localizedDescription))
         }
+    }
+
+    private func getICloudContainerUrl(containerId: String, result: @escaping FlutterResult) {
+        guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId) else {
+            result(containerError)
+            return
+        }
+        DebugHelper.log("containerURL: \(containerURL.path)")
+        result(containerURL.path)
     }
 
 

--- a/ios/Classes/IcloudStorageSyncPlugin.swift
+++ b/ios/Classes/IcloudStorageSyncPlugin.swift
@@ -34,6 +34,8 @@ public class IcloudStorageSyncPlugin: NSObject, FlutterPlugin {
             } else {
                 result(FlutterError(code: "INVALID_ARGUMENT", message: "containerId not provided", details: nil))
             }
+        case "isICloudAvailable":
+            isICloudAvailable(result)
         case "upload":
             upload(call, result) 
         case "delete":
@@ -172,6 +174,11 @@ public class IcloudStorageSyncPlugin: NSObject, FlutterPlugin {
         DebugHelper.log("containerURL: \(containerURL.path)")
         result(containerURL.path)
     }
+
+  private func isICloudAvailable(_ result: @escaping FlutterResult) {
+    let isAvailable = FileManager.default.ubiquityIdentityToken != nil
+    result(isAvailable)
+  }
 
 
   private func upload(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {

--- a/lib/icloud_storage_sync.dart
+++ b/lib/icloud_storage_sync.dart
@@ -13,6 +13,13 @@ class IcloudStorageSync {
     return IcloudStorageSyncPlatform.instance.getPlatformVersion();
   }
 
+  /// Returns the absolute path of the iCloud container directory for [containerId].
+  Future<String?> getContainerUrl({required String containerId}) {
+    return IcloudStorageSyncPlatform.instance.getContainerUrl(
+      containerId: containerId,
+    );
+  }
+
   /// Gathers metadata for all files in the specified iCloud container.
   ///
   /// [containerId] The ID of the iCloud container to query.

--- a/lib/icloud_storage_sync.dart
+++ b/lib/icloud_storage_sync.dart
@@ -20,6 +20,15 @@ class IcloudStorageSync {
     );
   }
 
+  /// Indicates whether iCloud is available on this device for iCloud Drive Documents.
+  ///
+  /// This checks if the system exposes a ubiquity identity token, which is
+  /// present only when the user is signed into iCloud and the feature is
+  /// enabled.
+  Future<bool> isICloudAvailable() {
+    return IcloudStorageSyncPlatform.instance.isICloudAvailable();
+  }
+
   /// Gathers metadata for all files in the specified iCloud container.
   ///
   /// [containerId] The ID of the iCloud container to query.

--- a/lib/icloud_storage_sync_method_channel.dart
+++ b/lib/icloud_storage_sync_method_channel.dart
@@ -19,6 +19,13 @@ class MethodChannelIcloudStorageSync extends IcloudStorageSyncPlatform {
     return version;
   }
 
+  @override
+  Future<String?> getContainerUrl({required String containerId}) async {
+    return await methodChannel.invokeMethod<String>('getICloudContainerUrl', {
+      'containerId': containerId,
+    });
+  }
+
   /// Gathers iCloud files and their metadata.
   ///
   /// [containerId] is the iCloud container identifier.

--- a/lib/icloud_storage_sync_method_channel.dart
+++ b/lib/icloud_storage_sync_method_channel.dart
@@ -26,6 +26,14 @@ class MethodChannelIcloudStorageSync extends IcloudStorageSyncPlatform {
     });
   }
 
+  @override
+  Future<bool> isICloudAvailable() async {
+    final available = await methodChannel.invokeMethod<bool>(
+      'isICloudAvailable',
+    );
+    return available ?? false;
+  }
+
   /// Gathers iCloud files and their metadata.
   ///
   /// [containerId] is the iCloud container identifier.

--- a/lib/icloud_storage_sync_platform_interface.dart
+++ b/lib/icloud_storage_sync_platform_interface.dart
@@ -40,6 +40,13 @@ abstract class IcloudStorageSyncPlatform extends PlatformInterface {
     throw UnimplementedError('getContainerUrl() has not been implemented.');
   }
 
+  /// Determines whether iCloud is available for iCloud Drive Documents by checking the ubiquity identity token.
+  ///
+  /// Returns `true` when a token is present otherwise returns `false`.
+  Future<bool> isICloudAvailable() async {
+    throw UnimplementedError('isICloudAvailable() has not been implemented.');
+  }
+
   /// Gathers all the files' metadata from the iCloud container.
   ///
   /// [containerId] is the iCloud Container Id.

--- a/lib/icloud_storage_sync_platform_interface.dart
+++ b/lib/icloud_storage_sync_platform_interface.dart
@@ -35,6 +35,11 @@ abstract class IcloudStorageSyncPlatform extends PlatformInterface {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
+  /// Returns the absolute path of the iCloud container URL.
+  Future<String?> getContainerUrl({required String containerId}) async {
+    throw UnimplementedError('getContainerUrl() has not been implemented.');
+  }
+
   /// Gathers all the files' metadata from the iCloud container.
   ///
   /// [containerId] is the iCloud Container Id.

--- a/macos/Classes/IcloudStorageSyncPlugin.swift
+++ b/macos/Classes/IcloudStorageSyncPlugin.swift
@@ -32,6 +32,8 @@ public class IcloudStorageSyncPlugin: NSObject, FlutterPlugin {
       } else {
            result(FlutterError(code: "INVALID_ARGUMENT", message: "containerId not provided", details: nil))
       }
+    case "isICloudAvailable":
+      isICloudAvailable(result)
     case "upload":
       upload(call, result)
     case "download":
@@ -220,6 +222,11 @@ public class IcloudStorageSyncPlugin: NSObject, FlutterPlugin {
     }
     DebugHelper.log("containerURL: \(containerURL.path)")
     result(containerURL.path)
+  }
+  
+  private func isICloudAvailable(_ result: @escaping FlutterResult) {
+    let isAvailable = FileManager.default.ubiquityIdentityToken != nil
+    result(isAvailable)
   }
   
   private func addUploadObservers(query: NSMetadataQuery, eventChannelName: String) {

--- a/macos/Classes/IcloudStorageSyncPlugin.swift
+++ b/macos/Classes/IcloudStorageSyncPlugin.swift
@@ -25,6 +25,13 @@ public class IcloudStorageSyncPlugin: NSObject, FlutterPlugin {
          } else {
              result(FlutterError(code: "INVALID_ARGUMENT", message: "containerId not provided", details: nil))
          }
+    case "getICloudContainerUrl":
+      if let args = call.arguments as? [String: Any],
+         let containerId = args["containerId"] as? String {
+           getICloudContainerUrl(containerId: containerId, result: result)
+      } else {
+           result(FlutterError(code: "INVALID_ARGUMENT", message: "containerId not provided", details: nil))
+      }
     case "upload":
       upload(call, result)
     case "download":
@@ -205,8 +212,15 @@ public class IcloudStorageSyncPlugin: NSObject, FlutterPlugin {
     
     result(nil)
   }
-  
 
+  private func getICloudContainerUrl(containerId: String, result: @escaping FlutterResult) {
+    guard let containerURL = FileManager.default.url(forUbiquityContainerIdentifier: containerId) else {
+      result(containerError)
+      return
+    }
+    DebugHelper.log("containerURL: \(containerURL.path)")
+    result(containerURL.path)
+  }
   
   private func addUploadObservers(query: NSMetadataQuery, eventChannelName: String) {
     NotificationCenter.default.addObserver(forName: NSNotification.Name.NSMetadataQueryDidFinishGathering, object: query, queue: query.operationQueue) { [self] (notification) in

--- a/test/icloud_storage_sync_test.dart
+++ b/test/icloud_storage_sync_test.dart
@@ -12,6 +12,10 @@ class MockIcloudStorageSyncPlatform
   Future<String?> getPlatformVersion() => Future.value('42');
 
   @override
+  Future<String?> getContainerUrl({required String containerId}) =>
+      throw UnimplementedError();
+
+  @override
   Future<void> delete(
       {required String containerId, required String relativePath}) {
     throw UnimplementedError();

--- a/test/icloud_storage_sync_test.dart
+++ b/test/icloud_storage_sync_test.dart
@@ -58,6 +58,11 @@ class MockIcloudStorageSyncPlatform
       StreamHandler<double>? onProgress}) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<bool> isICloudAvailable() {
+    throw UnimplementedError();
+  }
 }
 
 void main() {


### PR DESCRIPTION
## Checklist
- [x] Added native `getICloudContainerUrl` method. 
- [x] Added `isICloudAvailable` based on `ubiquityIdentityToken`.
- [x] Exposed both helpers via the platform interface and public `IcloudStorageSync` API.
- [x] Added documentations to clarify the new behaviours.

## Description
This PR introduces two helper methods:

1. `getICloudContainerUrl`: gets and returns the value for the ubiquity container path.
2. `isICloudAvailable`: helps check the availability of iCloud for iCloud Drive Documents using presence of the `ubiquityIdentityToken` to determine whether iCloud Drive Documents are accessible or enabled on the current device. 